### PR TITLE
fix: `APPS_DIRS` overriding downstream image values

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -26,7 +26,7 @@ CURRENT_GID=$(id -g gwb || echo -1)
 
 # $APP_DIRS - Directories to fix permissions for downstream image
 # All directories to fix permissions
-PERMISSIONS_DIRS="$GWB_HOME $XDG_RUNTIME_DIR $APP_DIRS"
+PERMISSIONS_DIRS="$GWB_HOME $XDG_RUNTIME_DIR ${APP_DIRS:-}"
 
 echo "Current UID:GID = ${CURRENT_UID:-<missing>}:${CURRENT_GID:-<missing>}"
 echo "Target UID:GID = $PUID:$PGID"


### PR DESCRIPTION
# GUI web Base

<div align="center">
  <img src="https://raw.githubusercontent.com/Aandree5/gui-web-base/refs/heads/main/images/logo_128.png" alt="Logo" />
  
  <b>Thank you for your contribution.  Please ensure your pull request meets the requirements in the checklist below.</b>
</div>

## Description
<!-- Concise description of what this PR does -->

## Checklist

- [ ] Docker image builds and runs successfully (`docker build`, `docker run`)
- [ ] Pre-commit hooks pass
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Docs updated (if applicable)

## Related Issues / PRs
<!-- Link to any related discussions -->
